### PR TITLE
Fix GitHub Actions Docker cache error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
           push: true
           # Cache layers for faster subsequent builds
           cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
 
 


### PR DESCRIPTION
- Remove unsupported cache-to configuration that was causing build failures
- Keep cache-from: type=gha for faster builds (supported by default driver)
- Resolves error: 'Cache export is not supported for the docker driver'

✅ GitHub Actions should now build and publish Docker images successfully!