### PR TITLE
Add production origin to CORS configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,8 +18,10 @@ const MONGO_URI = process.env.MONGO_URI || 'mongodb://mongo:27017/ienza-tech';
 
 // Configure CORS - allow Angular frontend
 app.use(cors({
-  // Standardised Angular dev port
-  origin: 'http://localhost:4200',
+  origin: [
+    'http://localhost:4200',          // Development
+    'https://blog.ienza.tech'         // Production
+  ],
   methods: ['GET', 'POST', 'PUT', 'DELETE'],
   allowedHeaders: ['Content-Type', 'Authorization']
 }));


### PR DESCRIPTION
🔧 CORS Update: Support both development and production origins
- Added https://blog.ienza.tech to allowed origins array
- Maintains http://localhost:4200 for local development
- Works with nginx proxy setup (nginx CORS header removed)

✅ Admin editor can now make API calls from production:
- Development: http://localhost:4200 → blog-server ✅
- Production: https://blog.ienza.tech → nginx → blog-server ✅

Fixes CORS error: Response to preflight request doesn't pass access control check