### PR TITLE
Auto-generate date field when not provided by admin editor

### DIFF
--- a/server.js
+++ b/server.js
@@ -170,6 +170,9 @@ app.post('/manage/add', upload.array('files', 5), async (req, res) => {
     } else if (Array.isArray(tags)) {
       tagsArray = tags;
     }
+
+    // Auto-generate date if not provided (admin editor doesn't send date)
+    const blogDate = date || new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
     
     // Create new blog
     const newBlog = new Blog({
@@ -177,7 +180,7 @@ app.post('/manage/add', upload.array('files', 5), async (req, res) => {
       title,
       text,
       story,
-      date,
+      date: blogDate,
       files
     });
     


### PR DESCRIPTION
🐛 Issue: Blog validation failing with 'Path date is required'
- Admin editor doesn't send date field in POST request
- Blog schema requires date field (required: true)
- Server was trying to save undefined date value

✅ Solution: Auto-generate date if not provided
- Added logic: blogDate = date || new Date().toISOString().split('T')[0]
- Uses YYYY-MM-DD format (ISO date string)
- Admin editor now works without date validation errors

🎯 Expected behavior:
- Admin posts with date: Uses provided date ✅
- Admin posts without date: Auto-generates today's date ✅
- No more 'Path date is required' errors ✅